### PR TITLE
Live site config

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -119,6 +119,8 @@ class Kernel extends ConsoleKernel
             )
         );
 
+	$apiContext->setConfig(array('mode' => env('PAYPAL_API_MODE')));
+
         $jobs = Job::where('status', '=', 'working')->where('next_payment_date','<=',date('Y-m-d H:i:s'))->get();
         if($jobs->count() == 0){
             return false;

--- a/app/Http/Controllers/CreditCardController.php
+++ b/app/Http/Controllers/CreditCardController.php
@@ -35,7 +35,7 @@ class CreditCardController extends Controller
             )
         );
 
-
+	$apiContext->setConfig(array('mode' => env('PAYPAL_API_MODE')));
 
         $card = new CreditCard();
         $card ->setType($this->cardType($input['card_number']))

--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -181,6 +181,8 @@ class OrderController extends Controller
             )
         );
 
+	$apiContext->setConfig(array('mode' => env('PAYPAL_API_MODE')));
+
         $creditCardToken = new CreditCardToken();
         $creditCardToken->setCreditCardId($creditCard->card_id);
 

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -155,6 +155,8 @@ Route::group(['prefix' => 'test'], function(){
             )
         );
 
+	$apiContext->setConfig(array('mode' => env('PAYPAL_API_MODE')));
+
         $payouts = new \PayPal\Api\Payout();
         $senderBatchHeader = new \PayPal\Api\PayoutSenderBatchHeader();
         $senderBatchHeader->setSenderBatchId(uniqid())


### PR DESCRIPTION
Adds a setConfig command to any apiContext so that we can toggle between PayPal sandbox mode and live mode.

Already tested on the live site.